### PR TITLE
Fix google font loading over ssl

### DIFF
--- a/plugins/defaulttheme/css/fonts.css
+++ b/plugins/defaulttheme/css/fonts.css
@@ -1,10 +1,10 @@
-@import url(http://fonts.googleapis.com/css?family=Roboto);
-@import url(http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700);
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:400,600,700,300);
-@import url(http://fonts.googleapis.com/css?family=Montserrat:400,700);
-@import url(http://fonts.googleapis.com/css?family=Lato:300,400,700);
-@import url(http://fonts.googleapis.com/css?family=Roboto+Slab:400,300,700);
-@import url(http://fonts.googleapis.com/css?family=Varela+Round);
+@import url(//fonts.googleapis.com/css?family=Roboto);
+@import url(//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700);
+@import url(//fonts.googleapis.com/css?family=Open+Sans:400,600,700,300);
+@import url(//fonts.googleapis.com/css?family=Montserrat:400,700);
+@import url(//fonts.googleapis.com/css?family=Lato:300,400,700);
+@import url(//fonts.googleapis.com/css?family=Roboto+Slab:400,300,700);
+@import url(//fonts.googleapis.com/css?family=Varela+Round);
 
 html {
     font-family: Open Sans, Helvetica Neue, Open Sans, Source Sans Pro, Montserrat, Varela Round;


### PR DESCRIPTION
This commit fixes google font loading in most security conscious browsers over ssl by letting the browser decide wether to use ssl or not to.