### PR TITLE
Use bind for the logger when it is available.

### DIFF
--- a/apiclient/logger.js
+++ b/apiclient/logger.js
@@ -1,6 +1,8 @@
 ﻿var Logger = {
 
-    log: function (str) {
+    //Since the log function simply calls "console.log" use bind if it exists
+    //This way the correct file/line is logged in the console
+    log: Function.prototype.bind ? console.log.bind(console) : function (str) {
         console.log(str);
     }
 };


### PR DESCRIPTION
Currently the logger is just a wrapper of console log. The problem is that all logged lines in the console point to the file of the logger (logger.js:4). By using bind the console displays the line from which the logger was called.

Note that if you need to do more than just call console.log you'll have to move back to using an anonymous function for calling console.log.