### PR TITLE
Fix loading from the filesystem.

### DIFF
--- a/js/require/requirecss.js
+++ b/js/require/requirecss.js
@@ -37,7 +37,7 @@ define(function () {
             packageName = 'theme';
         }
 
-        if (url.indexOf('http') != 0) {
+        if (url.indexOf('http') != 0 && url.indexOf('file:') != 0) {
             url = config.baseUrl + url;
         }
 

--- a/js/require/requirehtml.js
+++ b/js/require/requirehtml.js
@@ -17,7 +17,7 @@ define(function () {
 
         var url = cssId + '.html';
 
-        if (url.indexOf('http') != 0) {
+        if (url.indexOf('http') != 0 && url.indexOf('file:') != 0) {
             url = config.baseUrl + url;
         }
 

--- a/js/routes.js
+++ b/js/routes.js
@@ -88,7 +88,7 @@
 
             var url = route.contentPath || route.path;
 
-            if (url.toLowerCase().indexOf('http') != 0) {
+            if (url.toLowerCase().indexOf('http') != 0 && url.indexOf('file:') != 0) {
                 url = baseUrl() + '/' + url;
             }
 


### PR DESCRIPTION
This fixes loading directly from the filesystem, without a server (as long as the browser allows it).
To try it Chrome you have to start Chrome with --allow-file-access-from-files. Firefox doesn't seem to need anything.

Fonts still wont work since it tries to load "file://fonts.googleapis.com/css?family=..." which is caused because of #146. Changes introduced in #146 should stay as is though, when loading from the filesystem the fonts should also get loaded from the filesystem.